### PR TITLE
Add depth to minimax algo

### DIFF
--- a/main.js
+++ b/main.js
@@ -383,15 +383,16 @@ function Computer(name, marker) {
       }
     }
 
-    function minimax(currBdSt, alpha, beta, currMark) {
+    function minimax(currBdSt, alpha, beta, currMark, depth=0) {
       // if at a terminal node return a score;
       if (checkIfWinnerFound(currBdSt, opponentMarker)) {
-        return -1;
+        return depth-10;
       } else if (checkIfWinnerFound(currBdSt, botMarker)) {
-        return 1;
+        return 10-depth;
       } else if (checkTie(currBdSt)) {
         return 0;
       }
+      depth += 1;
 
       const availableMoves = getValidMoves(currBdSt.getBoard());
       const movesCount = availableMoves.length;
@@ -402,7 +403,7 @@ function Computer(name, marker) {
         for (let i = 0; i < movesCount; i++) {
           move = availableMoves[i];
           currBdSt.addMarker(move[0], move[1], currMark); // make a possible move;
-          result = minimax(currBdSt, alpha, beta, opponentMarker);
+          result = minimax(currBdSt, alpha, beta, opponentMarker, depth);
           currBdSt.getBoard()[move[0]][move[1]].addToken("-"); // undo move made;
           alpha = Math.max(alpha, result);
           if (beta <= alpha) {
@@ -414,7 +415,7 @@ function Computer(name, marker) {
         for (let i = 0; i < movesCount; i++) {
           move = availableMoves[i];
           currBdSt.addMarker(move[0], move[1], currMark); // make a possible move;
-          result = minimax(currBdSt, alpha, beta, botMarker);
+          result = minimax(currBdSt, alpha, beta, botMarker, depth);
           currBdSt.getBoard()[move[0]][move[1]].addToken("-"); // undo move made;
           beta = Math.min(beta, result);
           if (beta <= alpha) {


### PR DESCRIPTION
This little change will make the AI a bit more efficient. For example, consider following move order (assuming cells are numbered from 1 to 9):

1. Bot selects cell 3
2. Player selects cell 1
3. Bot selects cell 6
4. Player selects cell 7

At this point the most efficient move for the bot is to select cell 9 and win the game. But instead it selects cell 4, because it evaluates cell 4 move as much a winning move as cell 9. It doesn't care that cell 4 move will take more moves to win the game than cell 9. Adding depth into the equation helps the AI to distinguish between a more efficient winning move and a less efficient winning move.

P.S. I just finished the same project yesterday and I was curious to try out someone else's implementation :D and it's my first pull request.